### PR TITLE
AccountRegistry - Accept an initial state rather than starting with an empty tree

### DIFF
--- a/contracts/AccountTree.sol
+++ b/contracts/AccountTree.sol
@@ -24,24 +24,34 @@ contract AccountTree {
     bytes32[DEPTH] public filledSubtreesLeft;
     bytes32[DEPTH - BATCH_DEPTH] public filledSubtreesRight;
 
-    constructor() {
+    /*
+     * To create an empty tree use DefaultAccountTree.sol
+     * It passes in:
+     * - initialRootLeft = zeros[DEPTH]
+     * - initialLeafIndexLeft = 0
+     * - initialFilledSubtreesLeft[i] = zeros[i]
+     */
+    constructor(
+        bytes32 initialRootLeft,
+        uint256 initialLeafIndexLeft,
+        bytes32[DEPTH] memory initialFilledSubtreesLeft
+    ) public {
         // prettier-ignore
         bytes32 firstZero = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
         // i = 0
         zeros[0] = firstZero;
-        filledSubtreesLeft[0] = firstZero;
         // i > 0
         for (uint256 i = 1; i < DEPTH; i++) {
             zeros[i] = keccak256(abi.encode(zeros[i - 1], zeros[i - 1]));
-            if (DEPTH > i) {
-                filledSubtreesLeft[i] = zeros[i];
-            }
             if (BATCH_DEPTH <= i && DEPTH > i) {
                 filledSubtreesRight[i - BATCH_DEPTH] = zeros[i];
             }
         }
 
-        rootLeft = keccak256(abi.encode(zeros[DEPTH - 1], zeros[DEPTH - 1]));
+        filledSubtreesLeft = initialFilledSubtreesLeft;
+        leafIndexLeft = initialLeafIndexLeft;
+
+        rootLeft = initialRootLeft;
         rootRight = keccak256(abi.encode(zeros[DEPTH - 1], zeros[DEPTH - 1]));
         root = keccak256(abi.encode(rootLeft, rootRight));
     }

--- a/contracts/BLSAccountRegistry.sol
+++ b/contracts/BLSAccountRegistry.sol
@@ -15,7 +15,12 @@ contract BLSAccountRegistry is AccountTree {
     event SinglePubkeyRegistered(uint256 pubkeyID);
     event BatchPubkeyRegistered(uint256 startID, uint256 endID);
 
-    constructor(Chooser _chooser) {
+    constructor(
+        Chooser _chooser,
+        bytes32 rootLeft,
+        uint256 leafIndexLeft,
+        bytes32[DEPTH] memory filledSubtreesLeft
+    ) public AccountTree(rootLeft, leafIndexLeft, filledSubtreesLeft) {
         chooser = _chooser;
     }
 

--- a/contracts/DefaultAccountTree.sol
+++ b/contracts/DefaultAccountTree.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.4;
+
+import { AccountTree } from "./AccountTree.sol";
+import { DefaultTreeParams } from "./DefaultTreeParams.sol";
+
+/**
+    The AccountTree constructor accepts an initial state, this contract passes it the
+    state of an empty tree.
+*/
+contract DefaultAccountTree is DefaultTreeParams, AccountTree {
+    // solhint-disable-next-line no-empty-blocks
+    constructor() public AccountTree(INITIAL_LEFT_ROOT, 0, initialSubtrees) {}
+}

--- a/contracts/DefaultBLSAccountRegistry.sol
+++ b/contracts/DefaultBLSAccountRegistry.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import { DefaultTreeParams } from "./DefaultTreeParams.sol";
+import { BLSAccountRegistry } from "./BLSAccountRegistry.sol";
+import { Chooser } from "./proposers/Chooser.sol";
+
+contract DefaultBLSAccountRegistry is DefaultTreeParams, BLSAccountRegistry {
+    constructor(Chooser _chooser)
+        public
+        BLSAccountRegistry(_chooser, INITIAL_LEFT_ROOT, 0, initialSubtrees)
+    {} // solhint-disable-line no-empty-blocks
+}

--- a/contracts/DefaultTreeParams.sol
+++ b/contracts/DefaultTreeParams.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.4;
+
+contract DefaultTreeParams {
+    bytes32 public constant INITIAL_LEFT_ROOT =
+        0x78ccaaab73373552f207a63599de54d7d8d0c1805f86ce7da15818d09f4cff62;
+
+    /*
+	These lines can be computed in two equivalent ways:
+	- initialSubtrees[n] = keccak256(
+	      abi.encode(initialSubtrees[n-1],
+	      abi.encode(initialSubtrees[n-1]
+	  )
+	- initialSubtrees[n] = AccountTree.zeroes[n]
+	*/
+    bytes32[31] public initialSubtrees = [
+        bytes32(
+            0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563
+        ),
+        0x633dc4d7da7256660a892f8f1604a44b5432649cc8ec5cb3ced4c4e6ac94dd1d,
+        0x890740a8eb06ce9be422cb8da5cdafc2b58c0a5e24036c578de2a433c828ff7d,
+        0x3b8ec09e026fdc305365dfc94e189a81b38c7597b3d941c279f042e8206e0bd8,
+        0xecd50eee38e386bd62be9bedb990706951b65fe053bd9d8a521af753d139e2da,
+        0xdefff6d330bb5403f63b14f33b578274160de3a50df4efecf0e0db73bcdd3da5, // 5
+        0x617bdd11f7c0a11f49db22f629387a12da7596f9d1704d7465177c63d88ec7d7,
+        0x292c23a9aa1d8bea7e2435e555a4a60e379a5a35f3f452bae60121073fb6eead,
+        0xe1cea92ed99acdcb045a6726b2f87107e8a61620a232cf4d7d5b5766b3952e10,
+        0x7ad66c0a68c72cb89e4fb4303841966e4062a76ab97451e3b9fb526a5ceb7f82,
+        0xe026cc5a4aed3c22a58cbd3d2ac754c9352c5436f638042dca99034e83636516, // 10
+        0x3d04cffd8b46a874edf5cfae63077de85f849a660426697b06a829c70dd1409c,
+        0xad676aa337a485e4728a0b240d92b3ef7b3c372d06d189322bfd5f61f1e7203e,
+        0xa2fca4a49658f9fab7aa63289c91b7c7b6c832a6d0e69334ff5b0a3483d09dab,
+        0x4ebfd9cd7bca2505f7bef59cc1c12ecc708fff26ae4af19abe852afe9e20c862,
+        0x2def10d13dd169f550f578bda343d9717a138562e0093b380a1120789d53cf10, // 15
+        0x776a31db34a1a0a7caaf862cffdfff1789297ffadc380bd3d39281d340abd3ad,
+        0xe2e7610b87a5fdf3a72ebe271287d923ab990eefac64b6e59d79f8b7e08c46e3,
+        0x504364a5c6858bf98fff714ab5be9de19ed31a976860efbd0e772a2efe23e2e0,
+        0x4f05f4acb83f5b65168d9fef89d56d4d77b8944015e6b1eed81b0238e2d0dba3,
+        0x44a6d974c75b07423e1d6d33f481916fdd45830aea11b6347e700cd8b9f0767c, // 20
+        0xedf260291f734ddac396a956127dde4c34c0cfb8d8052f88ac139658ccf2d507,
+        0x6075c657a105351e7f0fce53bc320113324a522e8fd52dc878c762551e01a46e,
+        0x6ca6a3f763a9395f7da16014725ca7ee17e4815c0ff8119bf33f273dee11833b,
+        0x1c25ef10ffeb3c7d08aa707d17286e0b0d3cbcb50f1bd3b6523b63ba3b52dd0f,
+        0xfffc43bd08273ccf135fd3cacbeef055418e09eb728d727c4d5d5c556cdea7e3, // 25
+        0xc5ab8111456b1f28f3c7a0a604b4553ce905cb019c463ee159137af83c350b22,
+        0x0ff273fcbf4ae0f2bd88d6cf319ff4004f8d7dca70d4ced4e74d2c74139739e6,
+        0x7fa06ba11241ddd5efdc65d4e39c9f6991b74fd4b81b62230808216c876f827c,
+        0x7e275adf313a996c7e2950cac67caba02a5ff925ebf9906b58949f3e77aec5b9,
+        0x8f6162fa308d2b3a15dc33cffac85f13ab349173121645aedf00f471663108be // 30
+    ];
+}

--- a/contracts/test/TestAccountTree.sol
+++ b/contracts/test/TestAccountTree.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import { AccountTree } from "../AccountTree.sol";
+import { DefaultAccountTree } from "../DefaultAccountTree.sol";
 
-contract TestAccountTree is AccountTree {
+contract TestAccountTree is DefaultAccountTree {
     function updateSingle(bytes32 leaf) external returns (uint256) {
         uint256 operationGasCost = gasleft();
         _updateSingle(leaf);

--- a/test/fast/registry.test.ts
+++ b/test/fast/registry.test.ts
@@ -1,6 +1,7 @@
 import {
     BLSAccountRegistry,
-    BLSAccountRegistry__factory,
+    DefaultBLSAccountRegistry,
+    DefaultBLSAccountRegistry__factory,
     ProofOfBurn__factory
 } from "../../types/ethers-contracts";
 
@@ -29,7 +30,7 @@ function pubkeyToLeaf(uncompressedMcl: mcl.mclG2) {
 }
 
 describe("Registry", async () => {
-    let registry: BLSAccountRegistry;
+    let registry: DefaultBLSAccountRegistry;
     let treeLeft: MemoryTree;
     let treeRight: MemoryTree;
     beforeEach(async function() {
@@ -39,9 +40,9 @@ describe("Registry", async () => {
             accounts[0]
         ).deploy();
         await proofOfBurn.deployed();
-        registry = await new BLSAccountRegistry__factory(accounts[0]).deploy(
-            proofOfBurn.address
-        );
+        registry = await new DefaultBLSAccountRegistry__factory(
+            accounts[0]
+        ).deploy(proofOfBurn.address);
         DEPTH = (await registry.DEPTH()).toNumber();
         BATCH_DEPTH = (await registry.BATCH_DEPTH()).toNumber();
         hasher = Hasher.new("bytes", ZERO_BYTES32);

--- a/test/slow/commit.create2transfer.test.ts
+++ b/test/slow/commit.create2transfer.test.ts
@@ -1,5 +1,6 @@
 import {
     BLSAccountRegistry__factory,
+    DefaultBLSAccountRegistry__factory,
     ProofOfBurn__factory,
     TestCreate2Transfer,
     TestCreate2Transfer__factory
@@ -37,9 +38,14 @@ describe("Rollup Create2Transfer Commitment", () => {
         await deployKeyless(signer, false);
         const proofOfBurn = await new ProofOfBurn__factory(signer).deploy();
         await proofOfBurn.deployed();
-        const registryContract = await new BLSAccountRegistry__factory(
+        const defaultRegistryContract = await new DefaultBLSAccountRegistry__factory(
             signer
         ).deploy(proofOfBurn.address);
+        const registryContract = BLSAccountRegistry__factory.connect(
+            defaultRegistryContract.address,
+            signer
+        );
+
         registry = await AccountRegistry.new(registryContract);
         const nUsersWithStates = 32;
         const nUserWithoutState = nUsersWithStates;

--- a/test/slow/commit.massMigration.test.ts
+++ b/test/slow/commit.massMigration.test.ts
@@ -5,6 +5,7 @@ import { StateTree } from "../../ts/stateTree";
 import { hexToUint8Array, randHex } from "../../ts/utils";
 import {
     BLSAccountRegistry__factory,
+    DefaultBLSAccountRegistry__factory,
     ProofOfBurn__factory,
     TestMassMigration,
     TestMassMigration__factory
@@ -39,9 +40,13 @@ describe("Rollup Mass Migration", () => {
         await deployKeyless(signer, false);
         const proofOfBurn = await new ProofOfBurn__factory(signer).deploy();
         await proofOfBurn.deployed();
-        const registryContract = await new BLSAccountRegistry__factory(
+        const defaultRegistryContract = await new DefaultBLSAccountRegistry__factory(
             signer
         ).deploy(proofOfBurn.address);
+        const registryContract = BLSAccountRegistry__factory.connect(
+            defaultRegistryContract.address,
+            signer
+        );
 
         registry = await AccountRegistry.new(registryContract);
         users = Group.new({ n: 32, domain: DOMAIN });

--- a/test/slow/commit.transfer.test.ts
+++ b/test/slow/commit.transfer.test.ts
@@ -1,8 +1,9 @@
 import {
+    BLSAccountRegistry__factory,
+    DefaultBLSAccountRegistry__factory,
     ProofOfBurn__factory,
     TestTransfer,
-    TestTransfer__factory,
-    BLSAccountRegistry__factory
+    TestTransfer__factory
 } from "../../types/ethers-contracts";
 import { serialize } from "../../ts/tx";
 import * as mcl from "../../ts/mcl";
@@ -35,9 +36,13 @@ describe("Rollup Transfer Commitment", () => {
         await deployKeyless(signer, false);
         const proofOfBurn = await new ProofOfBurn__factory(signer).deploy();
         await proofOfBurn.deployed();
-        const registryContract = await new BLSAccountRegistry__factory(
+        const defaultRegistryContract = await new DefaultBLSAccountRegistry__factory(
             signer
         ).deploy(proofOfBurn.address);
+        const registryContract = BLSAccountRegistry__factory.connect(
+            defaultRegistryContract.address,
+            signer
+        );
 
         registry = await AccountRegistry.new(registryContract);
         users = Group.new({ n: 32, domain: DOMAIN });

--- a/ts/deploy.ts
+++ b/ts/deploy.ts
@@ -6,6 +6,7 @@ import {
     DepositManager__factory,
     Rollup__factory,
     BLSAccountRegistry__factory,
+    DefaultBLSAccountRegistry__factory,
     FrontendGeneric__factory,
     FrontendTransfer__factory,
     FrontendMassMigration__factory,
@@ -77,10 +78,18 @@ export async function deployAll(
         chooserAddress = proofOfBurn.address;
     }
 
-    const blsAccountRegistry = await new BLSAccountRegistry__factory(
+    const defaultAccountRegistry = await new DefaultBLSAccountRegistry__factory(
         signer
     ).deploy(chooserAddress);
-    await waitAndRegister(blsAccountRegistry, "blsAccountRegistry", verbose);
+    await waitAndRegister(
+        defaultAccountRegistry,
+        "blsAccountRegistry",
+        verbose
+    );
+    const blsAccountRegistry = BLSAccountRegistry__factory.connect(
+        defaultAccountRegistry.address,
+        signer
+    );
 
     // deploy Token registry contract
     const tokenRegistry = await new TokenRegistry__factory(signer).deploy();


### PR DESCRIPTION
Instead of computing `filledSubtreesLeft` we accept a parameter which is copied over verbatim. This allows us to deploy the contract with an initial state containing a large number of accounts.

This gives the deployer the ability to deploy an AccountRegistry with an invalid state, but I believe the worst effect this can have is to reduce the effective size of the Registry.