### PR TITLE
Hubble migration: larger custom token supply

### DIFF
--- a/contracts/test/CustomToken.sol
+++ b/contracts/test/CustomToken.sol
@@ -9,6 +9,6 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  */
 contract CustomToken is ERC20, Ownable {
     constructor(string memory name, string memory symbol) ERC20(name, symbol) {
-        _mint(msg.sender, 1e27);
+        _mint(msg.sender, 1e31);
     }
 }


### PR DESCRIPTION
This PR bumps the CustomToken supply in order to stop migrations from failing during deployment.

During deployment Hubble sums up the total amount of token held by all genesis accounts and then transfers that amount of CustomToken into the vault. Our current state has a large enough supply that this call now fails unless it is bumped.
